### PR TITLE
feat: PostgresTap uses a singleton Connector

### DIFF
--- a/tap_postgres/tap.py
+++ b/tap_postgres/tap.py
@@ -4,13 +4,14 @@ from typing import List
 
 from singer_sdk import SQLTap, SQLStream
 from singer_sdk import typing as th  # JSON schema typing helpers
-from tap_postgres.client import PostgresStream
+from tap_postgres.client import PostgresConnector, PostgresStream
 
 
 class TapPostgres(SQLTap):
     """Postgres tap class."""
     name = "tap-postgres"
     default_stream_class = PostgresStream
+    _connector: PostgresConnector = None
 
     config_jsonschema = th.PropertiesList(
         th.Property(
@@ -20,3 +21,25 @@ class TapPostgres(SQLTap):
             description="Example postgresql://postgres:postgres@localhost:5432/postgres"
         ),
     ).to_dict()
+
+
+    def get_connector(self) -> PostgresConnector:
+        """Get a configured connector for this Tap.
+
+        Connector is a singleton (one instance is used by the Tap and Streams).
+        """
+        if not self._connector:
+            self._connector = PostgresConnector(self.config)
+        return self._connector
+
+    def discover_streams(self) -> List[PostgresStream]:
+        """Initialize all available streams and return them as a list.
+
+        Returns:
+            List of discovered Stream objects.
+        """
+        result: list[PostgresStream] = []
+        return [
+            PostgresStream(self, catalog_entry, connector=self.get_connector())
+            for catalog_entry in self.catalog_dict["streams"]
+        ]


### PR DESCRIPTION
Solve #6.

[See Meltano SDK issue #1352](https://github.com/meltano/sdk/issues/1352) for a detailed conversation about this change and the issues it solves.

Before changes, tests fail with `sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) connection to server at "localhost" (::1), port 5432 failed: FATAL:  sorry, too many clients already`.

These changes get tests passing bc there is now one SQLAlchemy Engine managing all connections (rather than an arbitrarily large number of Engines, depending on the number of streams a PostgresTap instantiates). There's still some other work to be done to solve the underlying issue that was causing that error, but this is a substantial step forward.

After these changes, tests pass with just one warning, which is about a SQLAlchemy feature that's being deprecated in 2.0 (`RemovedIn20Warning: Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0.`)