### PR TITLE
ci: Add Python 3.11, remove Python 3.7. Clean up meltano.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,16 +6,12 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     services:
-      # Label used to access the service container
       postgres:
-        # Docker Hub image
         image: postgres
-        # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
-        # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -25,14 +21,9 @@ jobs:
       PIP_CONSTRAINT: .github/workflows/constraints.txt
     strategy:
       matrix:
-        include:
-        - {python-version: "3.10", session: "lint"}
-        - {python-version: "3.11", session: "pytest"}
-        - {python-version: "3.10", session: "pytest"}
-        - {python-version: "3.9", session: "pytest"}
-        - {python-version: "3.8", session: "pytest"}
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+    
     steps:
-
     - name: Checkout code
       uses: actions/checkout@v3.3.0
 
@@ -52,6 +43,9 @@ jobs:
     - name: Install dependencies
       run: |
         poetry install
-    - name: Run lint command from tox.ini
+    - name: Run pytest
       run: |
-        poetry run tox -e ${{ matrix.session }}
+        poetry run pytest
+    - name: Run lint
+      run: |
+        poetry run tox -e lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,10 @@ jobs:
       matrix:
         include:
         - {python-version: "3.10", session: "lint"}
+        - {python-version: "3.11", session: "pytest"}
         - {python-version: "3.10", session: "pytest"}
         - {python-version: "3.9", session: "pytest"}
         - {python-version: "3.8", session: "pytest"}
-        - {python-version: "3.7", session: "pytest"}
-
     steps:
 
     - name: Checkout code

--- a/meltano.yml
+++ b/meltano.yml
@@ -16,8 +16,7 @@ plugins:
     - name: sqlalchemy_url
       kind: password
     select:
-    - autoidm-ad_bamboohr_match.delta
-    - autoidm-ad_bamboohr_match.stg_activedirectory_userprincipalname
+    - "*.*"
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ keywords = [
 license = "Apache 2.0"
 
 [tool.poetry.dependencies]
-python = "<3.11,>=3.7.1"
+python = "<3.12,>=3.8.1"
 requests = "^2.25.1"
 singer-sdk = "^0.19.0"
 psycopg2-binary = "2.9.3"


### PR DESCRIPTION
Goal here is for our tests to start passing again. 