### PR TITLE
ci: Revert  Odd issues in actions, swapping poetry to pipx to see if it helps"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         pip --version
     - name: Install Poetry
       run: |
-        pipx install poetry
+        pip install poetry
         poetry --version
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Reverts MeltanoLabs/tap-postgres#119

CI now running pytest with the wrong python version and we're getting the same? issue here https://github.com/MeltanoLabs/tap-postgres/actions/runs/4851288228/jobs/8644990135?pr=113