### PR TITLE
chore: match hub overrides

### DIFF
--- a/tap_postgres/tap.py
+++ b/tap_postgres/tap.py
@@ -30,8 +30,9 @@ class TapPostgres(SQLTap):
             "sqlalchemy_url",
             th.StringType,
             required=True,
+            secret=True,
             description=(
-                "Example postgresql://postgres:postgres@localhost:5432/postgres"
+                "Example postgresql://[username]:[password]@localhost:5432/[db_name]"
             ),
         ),
         th.Property(


### PR DESCRIPTION
This syncs up the tap with the overrides from the hub https://hub.meltano.com/extractors/tap-postgres--meltanolabs/#sqlalchemy_url-setting.

We decided that sql alchemy url should be a password type by default since it includes user/pass and the example url was a bit hard to interpret without going to the docs because user/pass/dbname were all postgres.