### PR TITLE
fix: Appending `null` type to patched catalog in LOG_BASED replication

### DIFF
--- a/tap_postgres/tap.py
+++ b/tap_postgres/tap.py
@@ -535,7 +535,7 @@ class TapPostgres(SQLTap):
                         if isinstance(property.type, list):
                             property.type.append("null")
                         else:
-                            property.type = [*property.type, "null"]
+                            property.type = [property.type, "null"]
                 if new_stream.schema.required:
                     stream_modified = True
                     new_stream.schema.required = None

--- a/tap_postgres/tap.py
+++ b/tap_postgres/tap.py
@@ -532,7 +532,10 @@ class TapPostgres(SQLTap):
                 for property in new_stream.schema.properties.values():
                     if "null" not in property.type:
                         stream_modified = True
-                        property.type.append("null")
+                        if isinstance(property.type, list):
+                            property.type.append("null")
+                        else:
+                            property.type = [*property.type, "null"]
                 if new_stream.schema.required:
                     stream_modified = True
                     new_stream.schema.required = None


### PR DESCRIPTION
Closes #294