### PR TITLE
fix: Address missing `type` in for SDK-based type conforming

### DIFF
--- a/tap_postgres/client.py
+++ b/tap_postgres/client.py
@@ -125,7 +125,17 @@ class PostgresConnector(SQLConnector):
             type_name = type(sql_type).__name__
 
         if type_name is not None and type_name in ("JSONB", "JSON"):
-            return {}
+            return {
+                "anyOf": [
+                    {"type": "object"},
+                    {"type": "array"},
+                    {"type": "string"},
+                    {"type": "number"},
+                    {"type": "integer"},
+                    {"type": "boolean"},
+                    {"type": "null"},
+                ],
+            }
 
         if (
             type_name is not None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -237,8 +237,18 @@ def test_jsonb_json():
             "stream" in schema_message
             and schema_message["stream"] == altered_table_name
         ):
-            assert schema_message["schema"]["properties"]["column_jsonb"] == {}
-            assert schema_message["schema"]["properties"]["column_json"] == {}
+            props = schema_message["schema"]["properties"]
+            all_types = [
+                {"type": "object"},
+                {"type": "array"},
+                {"type": "string"},
+                {"type": "number"},
+                {"type": "integer"},
+                {"type": "boolean"},
+                {"type": "null"},
+            ]
+            assert props["column_jsonb"]["anyOf"] == all_types
+            assert props["column_json"]["anyOf"] == all_types
     assert test_runner.records[altered_table_name][0] == {
         "column_jsonb": {"foo": "bar"},
         "column_json": {"baz": "foo"},


### PR DESCRIPTION
See https://github.com/MeltanoLabs/tap-postgres/pull/239#issuecomment-1830353511
