### PR TITLE
feat: Object validation

### DIFF
--- a/tap_postgres/client.py
+++ b/tap_postgres/client.py
@@ -12,8 +12,8 @@ import typing
 from functools import cached_property
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Mapping, Optional, Type, Union
-import pendulum
 
+import pendulum
 import psycopg2
 import singer_sdk.helpers._typing
 import sqlalchemy
@@ -54,13 +54,19 @@ def patched_conform(
         epoch = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
         timedelta_from_epoch = epoch + elem
         if timedelta_from_epoch.tzinfo is None:
-            timedelta_from_epoch = timedelta_from_epoch.replace(tzinfo=datetime.timezone.utc)
+            timedelta_from_epoch = timedelta_from_epoch.replace(
+                tzinfo=datetime.timezone.utc
+            )
         return timedelta_from_epoch.isoformat()
     if isinstance(elem, datetime.time):
         return str(elem)
     if isinstance(elem, bytes):
         # for BIT value, treat 0 as False and anything else as True
-        return elem != b"\x00" if singer_sdk.helpers._typing.is_boolean_type(property_schema) else elem.hex()
+        return (
+            elem != b"\x00"
+            if singer_sdk.helpers._typing.is_boolean_type(property_schema)
+            else elem.hex()
+        )
     return elem
 
 
@@ -139,13 +145,15 @@ class PostgresConnector(SQLConnector):
             type_name = sql_type
         elif isinstance(sql_type, sqlalchemy.types.TypeEngine):
             type_name = type(sql_type).__name__
-        
+
         # Should theoretically be th.AnyType().type_dict but that causes errors down
         # the line with an error like:
-        # singer_sdk.helpers._typing.EmptySchemaTypeError: Could not detect type from 
+        # singer_sdk.helpers._typing.EmptySchemaTypeError: Could not detect type from
         # empty type_dict. Did you forget to define a property in the stream schema?
         if type_name is not None and type_name in ("JSONB", "JSON"):
-            return {"type": ["string", "number", "integer", "array", "object", "boolean"]}
+            return {
+                "type": ["string", "number", "integer", "array", "object", "boolean"]
+            }
 
         if (
             type_name is not None

--- a/tap_postgres/client.py
+++ b/tap_postgres/client.py
@@ -56,11 +56,11 @@ def patched_conform(
     Returns:
         The appropriate json compatible type.
     """
-    if isinstance(elem, datetime.date): # not copied, original logic
+    if isinstance(elem, datetime.date):  # not copied, original logic
         return elem.isoformat()
-    if isinstance(elem, (datetime.datetime, pendulum.DateTime)): # copied
+    if isinstance(elem, (datetime.datetime, pendulum.DateTime)):  # copied
         return singer_sdk.helpers._typing.to_json_compatible(elem)
-    if isinstance(elem, datetime.timedelta): # copied
+    if isinstance(elem, datetime.timedelta):  # copied
         epoch = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
         timedelta_from_epoch = epoch + elem
         if timedelta_from_epoch.tzinfo is None:
@@ -68,9 +68,9 @@ def patched_conform(
                 tzinfo=datetime.timezone.utc
             )
         return timedelta_from_epoch.isoformat()
-    if isinstance(elem, datetime.time): # copied
+    if isinstance(elem, datetime.time):  # copied
         return str(elem)
-    if isinstance(elem, bytes): # copied, modified to import is_boolean_type
+    if isinstance(elem, bytes):  # copied, modified to import is_boolean_type
         # for BIT value, treat 0 as False and anything else as True
         # Will only due this for booleans, not `bytea` data.
         return (

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -212,8 +212,8 @@ def test_jsonb_json():
         {"column_jsonb": 3.14, "column_json": -9.3},
         {"column_jsonb": 22, "column_json": 10000000},
         {"column_jsonb": {}, "column_json": {}},
-        {"column_jsonb": ["bar","foo"], "column_json": ["foo", "baz"]},
-        {"column_jsonb": True, "column_json": False}
+        {"column_jsonb": ["bar", "foo"], "column_json": ["foo", "baz"]},
+        {"column_jsonb": True, "column_json": False},
     ]
 
     with engine.connect() as conn:
@@ -244,8 +244,28 @@ def test_jsonb_json():
             "stream" in schema_message
             and schema_message["stream"] == altered_table_name
         ):
-            assert schema_message["schema"]["properties"]["column_jsonb"] == {"type": ["string", "number", "integer", "array", "object", "boolean", "null"]}
-            assert schema_message["schema"]["properties"]["column_json"] == {"type": ["string", "number", "integer", "array", "object", "boolean", "null"]}
+            assert schema_message["schema"]["properties"]["column_jsonb"] == {
+                "type": [
+                    "string",
+                    "number",
+                    "integer",
+                    "array",
+                    "object",
+                    "boolean",
+                    "null",
+                ]
+            }
+            assert schema_message["schema"]["properties"]["column_json"] == {
+                "type": [
+                    "string",
+                    "number",
+                    "integer",
+                    "array",
+                    "object",
+                    "boolean",
+                    "null",
+                ]
+            }
     for i in range(len(rows)):
         assert test_runner.records[altered_table_name][i] == rows[i]
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -206,14 +206,21 @@ def test_jsonb_json():
         Column("column_jsonb", JSONB),
         Column("column_json", JSON),
     )
+
+    rows = [
+        {"column_jsonb": {"foo": "bar"}, "column_json": {"baz": "foo"}},
+        {"column_jsonb": 3.14, "column_json": -9.3},
+        {"column_jsonb": 22, "column_json": 10000000},
+        {"column_jsonb": {}, "column_json": {}},
+        {"column_jsonb": ["bar","foo"], "column_json": ["foo", "baz"]},
+        {"column_jsonb": True, "column_json": False}
+    ]
+
     with engine.connect() as conn:
         if table.exists(conn):
             table.drop(conn)
         metadata_obj.create_all(conn)
-        insert = table.insert().values(
-            column_jsonb={"foo": "bar"},
-            column_json={"baz": "foo"},
-        )
+        insert = table.insert().values(rows)
         conn.execute(insert)
     tap = TapPostgres(config=SAMPLE_CONFIG)
     tap_catalog = json.loads(tap.catalog_json_text)
@@ -237,12 +244,10 @@ def test_jsonb_json():
             "stream" in schema_message
             and schema_message["stream"] == altered_table_name
         ):
-            assert schema_message["schema"]["properties"]["column_jsonb"] == {}
-            assert schema_message["schema"]["properties"]["column_json"] == {}
-    assert test_runner.records[altered_table_name][0] == {
-        "column_jsonb": {"foo": "bar"},
-        "column_json": {"baz": "foo"},
-    }
+            assert schema_message["schema"]["properties"]["column_jsonb"] == {"type": ["string", "number", "integer", "array", "object", "boolean", "null"]}
+            assert schema_message["schema"]["properties"]["column_json"] == {"type": ["string", "number", "integer", "array", "object", "boolean", "null"]}
+    for i in range(len(rows)):
+        assert test_runner.records[altered_table_name][i] == rows[i]
 
 
 def test_decimal():


### PR DESCRIPTION
Modifies the schema for jsonb and json objects because using an empty schema was not previously function for all taps (ex: tap-csv).

Closes #303 