### PR TITLE
fix: Use `.mappings()` in cursor, to get rows as mappings

### DIFF
--- a/tap_postgres/client.py
+++ b/tap_postgres/client.py
@@ -282,7 +282,7 @@ class PostgresStream(SQLStream):
                 query = query.filter(replication_key_col >= start_val)
 
         with self.connector._connect() as con:
-            for row in con.execute(query).mappings().all():
+            for row in con.execute(query).mappings():
                 yield dict(row)
 
 

--- a/tap_postgres/client.py
+++ b/tap_postgres/client.py
@@ -283,7 +283,7 @@ class PostgresStream(SQLStream):
 
         with self.connector._connect() as con:
             for row in con.execute(query).mappings().all():
-                yield row
+                yield dict(row)
 
 
 class PostgresLogBasedStream(SQLStream):

--- a/tap_postgres/client.py
+++ b/tap_postgres/client.py
@@ -283,7 +283,7 @@ class PostgresStream(SQLStream):
 
         with self.connector._connect() as con:
             for row in con.execute(query).mappings().all():
-                yield dict(row)
+                yield row
 
 
 class PostgresLogBasedStream(SQLStream):

--- a/tap_postgres/client.py
+++ b/tap_postgres/client.py
@@ -283,7 +283,7 @@ class PostgresStream(SQLStream):
 
         with self.connector._connect() as con:
             for row in con.execute(query):
-                yield dict(row)
+                yield dict(row._mapping)
 
 
 class PostgresLogBasedStream(SQLStream):

--- a/tap_postgres/client.py
+++ b/tap_postgres/client.py
@@ -282,8 +282,8 @@ class PostgresStream(SQLStream):
                 query = query.filter(replication_key_col >= start_val)
 
         with self.connector._connect() as con:
-            for row in con.execute(query):
-                yield dict(row._mapping)
+            for row in con.execute(query).mappings().all():
+                yield dict(row)
 
 
 class PostgresLogBasedStream(SQLStream):


### PR DESCRIPTION
~This was fixed upstream in https://github.com/meltano/sdk/pull/1487, but this tap overrides `get_records`.~ 

I think https://github.com/meltano/sdk/pull/2094 is the only difference between the two implementations?

UPDATE: Using the private `._mapping` attribute makes me nervous so I opened https://github.com/meltano/sdk/pull/2095 and updated this PR.
