### PR TITLE
feat: :sparkles: add `maxLength` to schema

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -1,3 +1,6 @@
+default_environment: dev
+environments:
+  - name: dev
 version: 1
 send_anonymous_usage_stats: true
 project_id: "tap-postgres"
@@ -11,7 +14,7 @@ plugins:
     - catalog
     - discover
     config:
-      sqlalchemy_url: "postgresql://postgres:postgres@localhost:5432/postgres"
+      sqlalchemy_url: "postgresql://tobiascadee:password@localhost:5432/postgres"
     settings:
     - name: sqlalchemy_url
       kind: password
@@ -37,7 +40,7 @@ plugins:
     - name: ssl_client_private_key
       kind: password
     select:
-    - "*.*"
+    - "public-test.*"
   loaders:
   - name: target-jsonl
     variant: andyh1203


### PR DESCRIPTION
if the column has a length (e.g. varchar(256), propagate this length to maxLength in the schema. This can then be used in sql targets to create columns with the right type and size.

this is PR for this issue: https://github.com/MeltanoLabs/tap-postgres/issues/477