### PR TITLE
feat: Add json_as_object option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Built with the [Meltano Singer SDK](https://sdk.meltano.com).
 | sqlalchemy_url                    | False    | None                         | Example postgresql://[username]:[password]@localhost:5432/[db_name]                                                                                                                                                                                                                                      |
 | filter_schemas                    | False    | None                         | If an array of schema names is provided, the tap will only process the specified Postgres schemas and ignore others. If left blank, the tap automatically determines ALL available Postgres schemas.                                                                                                     |
 | dates_as_string                   | False    | 0                            | Defaults to false, if true, date, and timestamp fields will be Strings. If you see ValueError: Year is out of range, try setting this to True.                                                                                                                                                           |
+| json_as_object                    | False    | 0                            | Defaults to false, if true, json and jsonb fields will be Objects.                                                                                                     |
 | ssh_tunnel                        | False    | None                         | SSH Tunnel Configuration, this is a json object                                                                                                                                                                                                                                                          |
 | ssh_tunnel.enable                 | False    | 0                            | Enable an ssh tunnel (also known as bastion server), see the other ssh_tunnel.* properties for more details                                                                                                                                                                                              |
 | ssh_tunnel.host                   | False    | None                         | Host of the bastion server, this is the host we'll connect to via ssh                                                                                                                                                                                                                                    |
@@ -131,6 +132,8 @@ Create tests within the `tap_postgres/tests` subfolder and
 ```bash
 poetry run pytest
 ```
+
+NOTE: Running the tests requires a locally running postgres. See tests/settings.py for the expected configuration.
 
 You can also test the `tap-postgres` CLI interface directly using `poetry run`:
 

--- a/tap_postgres/tap.py
+++ b/tap_postgres/tap.py
@@ -177,6 +177,14 @@ class TapPostgres(SQLTap):
             default=False,
         ),
         th.Property(
+            "json_as_object",
+            th.BooleanType,
+            description=(
+                "Defaults to false, if true, json and jsonb fields will be Objects."
+            ),
+            default=False,
+        ),
+        th.Property(
             "ssh_tunnel",
             th.ObjectType(
                 th.Property(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -405,9 +405,9 @@ def test_json_as_object():
                     "null",
                 ]
             }
-    for expected_row, actual_row in zip(
-        rows, test_runner.records[altered_table_name], strict=True
-    ):
+
+    assert len(rows) == len(test_runner.records[altered_table_name])
+    for expected_row, actual_row in zip(rows, test_runner.records[altered_table_name]):
         assert actual_row == expected_row
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -405,8 +405,10 @@ def test_json_as_object():
                     "null",
                 ]
             }
-    for i in range(len(rows)):
-        assert test_runner.records[altered_table_name][i] == rows[i]
+    for expected_row, actual_row in zip(
+        rows, test_runner.records[altered_table_name], strict=True
+    ):
+        assert actual_row == expected_row
 
 
 def test_numeric_types():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -338,6 +338,77 @@ def test_jsonb_array():
         assert test_runner.records[altered_table_name][i] == rows[i]
 
 
+def test_json_as_object():
+    """Some use cases require JSON and JSONB columns to be typed as Objects."""
+    table_name = "test_json_as_object"
+    engine = sa.create_engine(SAMPLE_CONFIG["sqlalchemy_url"], future=True)
+
+    metadata_obj = sa.MetaData()
+    table = sa.Table(
+        table_name,
+        metadata_obj,
+        sa.Column("column_jsonb", JSONB),
+        sa.Column("column_json", JSON),
+    )
+
+    rows = [
+        {"column_jsonb": {"foo": "bar"}, "column_json": {"baz": "foo"}},
+        {"column_jsonb": 3.14, "column_json": -9.3},
+        {"column_jsonb": 22, "column_json": 10000000},
+        {"column_jsonb": {}, "column_json": {}},
+        {"column_jsonb": ["bar", "foo"], "column_json": ["foo", "baz"]},
+        {"column_jsonb": True, "column_json": False},
+    ]
+
+    with engine.begin() as conn:
+        table.drop(conn, checkfirst=True)
+        metadata_obj.create_all(conn)
+        insert = table.insert().values(rows)
+        conn.execute(insert)
+
+    copied_config = copy.deepcopy(SAMPLE_CONFIG)
+    # This should cause the same data to pass
+    copied_config["json_as_object"] = True
+
+    tap = TapPostgres(config=copied_config)
+    tap_catalog = json.loads(tap.catalog_json_text)
+    altered_table_name = f"{DB_SCHEMA_NAME}-{table_name}"
+
+    for stream in tap_catalog["streams"]:
+        if stream.get("stream") and altered_table_name not in stream["stream"]:
+            for metadata in stream["metadata"]:
+                metadata["metadata"]["selected"] = False
+        else:
+            for metadata in stream["metadata"]:
+                metadata["metadata"]["selected"] = True
+                if metadata["breadcrumb"] == []:
+                    metadata["metadata"]["replication-method"] = "FULL_TABLE"
+
+    test_runner = PostgresTestRunner(
+        tap_class=TapPostgres, config=SAMPLE_CONFIG, catalog=tap_catalog
+    )
+    test_runner.sync_all()
+    for schema_message in test_runner.schema_messages:
+        if (
+            "stream" in schema_message
+            and schema_message["stream"] == altered_table_name
+        ):
+            assert schema_message["schema"]["properties"]["column_jsonb"] == {
+                "type": [
+                    "object",
+                    "null",
+                ]
+            }
+            assert schema_message["schema"]["properties"]["column_json"] == {
+                "type": [
+                    "object",
+                    "null",
+                ]
+            }
+    for i in range(len(rows)):
+        assert test_runner.records[altered_table_name][i] == rows[i]
+
+
 def test_numeric_types():
     """Schema was wrong for Decimal objects. Check they are correctly selected."""
     table_name = "test_decimal"


### PR DESCRIPTION
To allow JSON and JSONB to be tapped as plain objects

See [this Slack thread](https://meltano.slack.com/archives/C069CQNHDNF/p1729784981090099) for context