### PR TITLE
Add Replication Buffer Setting

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -1,1 +1,6 @@
 """A Singer tap for Postgres, built with the Meltano SDK."""
+
+# Register custom date parsers to handle bad date values
+from .postgres_type_adapter import PostgresTypeAdapter
+adapter = PostgresTypeAdapter()
+adapter.register_parsers() 

--- a/tap_postgres/client.py
+++ b/tap_postgres/client.py
@@ -194,7 +194,7 @@ class PostgresStream(SQLStream):
     """Stream class for Postgres streams."""
 
     connector_class = PostgresConnector
-    supports_nulls_first = True
+    supports_nulls_first = False
 
     # JSONB Objects won't be selected without type_conformance_level to ROOT_ONLY
     TYPE_CONFORMANCE_LEVEL = TypeConformanceLevel.ROOT_ONLY

--- a/tap_postgres/client.py
+++ b/tap_postgres/client.py
@@ -243,8 +243,12 @@ class PostgresStream(SQLStream):
             query = query.order_by(order_by)
 
             start_val = self.get_starting_replication_key_value(context)
+            end_val = self.config.get("end_date")
+
             if start_val:
                 query = query.where(replication_key_col >= start_val)
+            if end_val is not None:
+                query = query.where(replication_key_col <= end_val)
 
         if self.ABORT_AT_RECORD_COUNT is not None:
             # Limit record count to one greater than the abort threshold. This ensures

--- a/tap_postgres/client.py
+++ b/tap_postgres/client.py
@@ -234,6 +234,7 @@ class PostgresStream(SQLStream):
         query = table.select()
 
         if self.replication_key:
+            self.logger.info(f"supports_nulls_first: {self.supports_nulls_first}")
             replication_key_col = table.columns[self.replication_key]
             order_by = (
                 sa.nulls_first(replication_key_col.asc())

--- a/tap_postgres/client.py
+++ b/tap_postgres/client.py
@@ -244,11 +244,16 @@ class PostgresStream(SQLStream):
 
             start_val = self.get_starting_replication_key_value(context)
             end_val = self.config.get("end_date")
+            buffer_seconds = self.config.get("replication_key_buffer_seconds")
 
             if start_val:
                 query = query.where(replication_key_col >= start_val)
             if end_val is not None:
                 query = query.where(replication_key_col <= end_val)
+            if buffer_seconds is not None:
+                current_time = datetime.datetime.now(datetime.timezone.utc)
+                buffer_time = current_time - datetime.timedelta(seconds=buffer_seconds)
+                query = query.where(replication_key_col < buffer_time)
 
         if self.ABORT_AT_RECORD_COUNT is not None:
             # Limit record count to one greater than the abort threshold. This ensures

--- a/tap_postgres/client.py
+++ b/tap_postgres/client.py
@@ -234,7 +234,6 @@ class PostgresStream(SQLStream):
         query = table.select()
 
         if self.replication_key:
-            self.logger.info(f"supports_nulls_first: {self.supports_nulls_first}")
             replication_key_col = table.columns[self.replication_key]
             order_by = (
                 sa.nulls_first(replication_key_col.asc())

--- a/tap_postgres/postgres_type_adapter.py
+++ b/tap_postgres/postgres_type_adapter.py
@@ -1,0 +1,88 @@
+import datetime
+import logging
+import psycopg2.extensions
+
+logger = logging.getLogger(__name__)
+
+class PostgresTypeAdapter:
+    # OIDs for PostgreSQL types. Query pg_type if these are not standard for your DB version.
+    DATE_OID = 1082  # date
+    TIMESTAMP_OID = 1114  # timestamp without timezone
+    TIMESTAMPTZ_OID = 1184  # timestamp with timezone
+
+    def __init__(self):
+        # The logger can be module-level or instance-level.
+        # Using the module-level logger here.
+        self.logger = logger 
+
+    def safe_parse_date(self, value, cur):
+        """Safely parse PostgreSQL date strings, returning None for errors or special values."""
+        if value is None:
+            return None
+
+        if isinstance(value, bytes):
+            try:
+                str_value = value.decode('utf-8')
+            except UnicodeDecodeError:
+                self.logger.warning(f"Could not decode bytes to UTF-8 for date parsing: {value!r}")
+                return None
+        else:
+            str_value = str(value)
+
+        if str_value == 'infinity' or str_value == '-infinity':
+            self.logger.debug(f"Parsed PostgreSQL special date value '{str_value}' as None.")
+            return None
+
+        try:
+            return datetime.datetime.strptime(str_value, '%Y-%m-%d').date()
+        except (ValueError, OverflowError) as e:
+            self.logger.warning(f"Could not parse date string '{str_value}' to a valid Python date. Error: {e}. Returning None.")
+            return None
+
+    def safe_parse_datetime(self, value, cur):
+        """Safely parse PostgreSQL timestamp/timestamptz strings, returning None for errors or special values."""
+        if value is None:
+            return None
+
+        if isinstance(value, bytes):
+            try:
+                str_value = value.decode('utf-8')
+            except UnicodeDecodeError:
+                self.logger.warning(f"Could not decode bytes to UTF-8 for datetime parsing: {value!r}")
+                return None
+        else:
+            str_value = str(value)
+
+        if str_value == 'infinity' or str_value == '-infinity':
+            self.logger.debug(f"Parsed PostgreSQL special datetime value '{str_value}' as None.")
+            return None
+
+        try:
+            # datetime.fromisoformat handles standard ISO 8601 formats from PostgreSQL
+            return datetime.datetime.fromisoformat(str_value)
+        except (ValueError, OverflowError) as e:
+            self.logger.warning(f"Could not parse datetime string '{str_value}' to a valid Python datetime. Error: {e}. Returning None.")
+            return None
+
+    def register_parsers(self):
+        """Registers custom parsers for date, timestamp, and timestamptz types with psycopg2."""
+        # psycopg2.extensions.new_typecaster seems to be missing in the environment,
+        # trying with psycopg2.extensions.new_type instead.
+        
+        # For DATE
+        date_type = psycopg2.extensions.new_type((self.DATE_OID,), "CUSTOM_DATE", self.safe_parse_date)
+        psycopg2.extensions.register_type(date_type)
+        self.logger.info(f"Custom safe date parser registered for OID {self.DATE_OID} using new_type.")
+
+        # For TIMESTAMP and TIMESTAMPTZ
+        # We need to register them separately if using new_type with a single OID list for the type name
+        
+        # TIMESTAMP
+        timestamp_type = psycopg2.extensions.new_type((self.TIMESTAMP_OID,), "CUSTOM_TIMESTAMP", self.safe_parse_datetime)
+        psycopg2.extensions.register_type(timestamp_type)
+        self.logger.info(f"Custom safe datetime parser registered for OID {self.TIMESTAMP_OID} (timestamp) using new_type.")
+
+        # TIMESTAMPTZ
+        timestamptz_type = psycopg2.extensions.new_type((self.TIMESTAMPTZ_OID,), "CUSTOM_TIMESTAMPTZ", self.safe_parse_datetime)
+        psycopg2.extensions.register_type(timestamptz_type)
+        self.logger.info(f"Custom safe datetime parser registered for OID {self.TIMESTAMPTZ_OID} (timestamptz) using new_type.")

--- a/tap_postgres/tap.py
+++ b/tap_postgres/tap.py
@@ -341,6 +341,14 @@ class TapPostgres(SQLTap):
                 "this choice. One of `FULL_TABLE`, `INCREMENTAL`, or `LOG_BASED`."
             ),
         ),
+        th.Property(
+            "end_date",
+            th.StringType,
+            description=(
+                "The date to end the replication. If not provided, the tap will "
+                "continue to replicate data indefinitely."
+            ),
+        ),
     ).to_dict()
 
     def get_sqlalchemy_url(self, config: Mapping[str, Any]) -> str:

--- a/tap_postgres/tap.py
+++ b/tap_postgres/tap.py
@@ -349,6 +349,16 @@ class TapPostgres(SQLTap):
                 "continue to replicate data indefinitely."
             ),
         ),
+        th.Property(
+            "replication_key_buffer_seconds",
+            th.IntegerType,
+            description=(
+                "Optional buffer in seconds to subtract from the current time when "
+                "filtering records by replication key. This helps avoid race conditions "
+                "by excluding recently updated data. For example, setting this to 300 "
+                "will only process records where the replication key is at least 5 minutes old."
+            ),
+        ),
     ).to_dict()
 
     def get_sqlalchemy_url(self, config: Mapping[str, Any]) -> str:

--- a/tests/test_postgres_type_adapter.py
+++ b/tests/test_postgres_type_adapter.py
@@ -1,0 +1,64 @@
+import datetime
+import pytest
+from tap_postgres.postgres_type_adapter import PostgresTypeAdapter
+
+# The 'cur' argument is not used by our parsing functions, so None is fine.
+MOCK_CURSOR = None
+
+@pytest.fixture(scope="module")
+def adapter():
+    """Provides a PostgresTypeAdapter instance for the tests."""
+    # Note: This will trigger the registration in PostgresTypeAdapter if it's set to auto-register on init.
+    # For these parsing unit tests, the registration state itself isn't directly tested,
+    # only the parsing methods' behavior.
+    return PostgresTypeAdapter()
+
+# Test cases for safe_parse_date
+DATE_TEST_CASES = [
+    ("2023-10-26", datetime.date(2023, 10, 26)),
+    ("infinity", None),
+    ("-infinity", None),
+    ("202229-01-01", None),  # Year out of Python's date range
+    ("0000-01-01", None),    # Year out of Python's date range (min year is 1)
+    ("2023-044-01", None),   # Malformed month
+    ("not-a-date", None),
+    (None, None),
+    (b"2023-11-15", datetime.date(2023, 11, 15)),
+    (b"\\xff\\xfe", None),  # Invalid UTF-8 bytes
+    (b"2023-30-30", None),  # Malformed date in bytes
+    ("0001-01-01", datetime.date(1, 1, 1)),      # Min valid date
+    ("9999-12-31", datetime.date(9999, 12, 31)), # Max valid date
+]
+
+@pytest.mark.parametrize("value, expected", DATE_TEST_CASES)
+def test_safe_parse_date(adapter, value, expected):
+    """Tests the safe_parse_date method of PostgresTypeAdapter."""
+    result = adapter.safe_parse_date(value, MOCK_CURSOR)
+    assert result == expected
+
+# Test cases for safe_parse_datetime
+DATETIME_TEST_CASES = [
+    ("2023-10-26T10:30:00", datetime.datetime(2023, 10, 26, 10, 30, 0)),
+    ("2023-10-26 10:30:00", datetime.datetime(2023, 10, 26, 10, 30, 0)), # Space separator
+    ("2023-10-26T10:30:00Z", datetime.datetime(2023, 10, 26, 10, 30, 0, tzinfo=datetime.timezone.utc)),
+    ("2023-10-26T10:30:00+01:00", datetime.datetime(2023, 10, 26, 10, 30, 0, tzinfo=datetime.timezone(datetime.timedelta(seconds=3600)))),
+    ("2023-10-26T10:30:00.123456", datetime.datetime(2023, 10, 26, 10, 30, 0, 123456)),
+    ("2023-10-26 10:30:00.123456-05:00", datetime.datetime(2023, 10, 26, 10, 30, 0, 123456, tzinfo=datetime.timezone(datetime.timedelta(seconds=-18000)))),
+    ("infinity", None),
+    ("-infinity", None),
+    ("10000-01-01T00:00:00", None),  # Year out of Python's datetime range
+    ("0000-01-01T00:00:00", None),    # Year out of Python's datetime range (min year is 1)
+    ("not-a-datetime", None),
+    (None, None),
+    (b"2023-11-15T12:00:00", datetime.datetime(2023, 11, 15, 12, 0, 0)),
+    (b"2023-11-15T12:00:00-05:00", datetime.datetime(2023, 11, 15, 12, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(seconds=-18000)))),
+    (b"\\xff\\xfeT00:00:00", None),  # Invalid UTF-8 bytes
+    ("0001-01-01T00:00:00", datetime.datetime(1, 1, 1, 0, 0, 0)),  # Min valid datetime
+    ("9999-12-31T23:59:59.999999", datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)), # Max valid datetime
+]
+
+@pytest.mark.parametrize("value, expected", DATETIME_TEST_CASES)
+def test_safe_parse_datetime(adapter, value, expected):
+    """Tests the safe_parse_datetime method of PostgresTypeAdapter."""
+    result = adapter.safe_parse_datetime(value, MOCK_CURSOR)
+    assert result == expected 

--- a/tests/test_replication_key.py
+++ b/tests/test_replication_key.py
@@ -2,6 +2,7 @@
 
 import copy
 import datetime
+import zoneinfo
 
 import sqlalchemy as sa
 from singer_sdk.singerlib import Catalog, StreamMetadata
@@ -156,6 +157,235 @@ def test_null_replication_key_without_start_date():
         len(test_runner.records[altered_table_name]) == 3  # noqa: PLR2004
     )  # All three records.
 
+
+def test_replication_key_buffer_seconds():
+    """Test that replication_key_buffer_seconds excludes recently updated records."""
+    table_name = "test_replication_key_buffer_seconds"
+    
+    # Create a config with a 300 second (5 minute) buffer
+    modified_config = copy.deepcopy(SAMPLE_CONFIG)
+    modified_config["replication_key_buffer_seconds"] = 300
+    
+    engine = sa.create_engine(modified_config["sqlalchemy_url"], future=True)
+
+    metadata_obj = sa.MetaData()
+    table = sa.Table(
+        table_name,
+        metadata_obj,
+        sa.Column("data", sa.String()),
+        sa.Column("updated_at", TIMESTAMP),
+    )
+    
+    current_time = datetime.datetime.now(datetime.timezone.utc)
+    
+    with engine.begin() as conn:
+        table.drop(conn, checkfirst=True)
+        metadata_obj.create_all(conn)
+        
+        # Insert record that's older than buffer (should be included)
+        old_record_time = current_time - datetime.timedelta(seconds=60*6)  # 6 minutes
+        insert = table.insert().values(
+            data="OldRecord", 
+            updated_at=old_record_time
+        )
+        conn.execute(insert)
+        
+        # Insert record that's within buffer (should be excluded)
+        recent_record_time = current_time - datetime.timedelta(seconds=60*4)  # 4 minutes ago
+        insert = table.insert().values(
+            data="RecentRecord", 
+            updated_at=recent_record_time
+        )
+        conn.execute(insert)
+    
+    tap = TapPostgres(config=modified_config)
+    tap_catalog = Catalog.from_dict(tap.catalog_dict)
+    altered_table_name = f"{DB_SCHEMA_NAME}-{table_name}"
+    
+    for stream in tap_catalog.streams:
+        if stream.stream and altered_table_name not in stream.stream:
+            for metadata in stream.metadata.values():
+                metadata.selected = False
+        else:
+            stream.replication_key = "updated_at"
+            for metadata in stream.metadata.values():
+                metadata.selected = True
+                if isinstance(metadata, StreamMetadata):
+                    metadata.forced_replication_method = "INCREMENTAL"
+                    metadata.replication_key = "updated_at"
+
+    test_runner = TapTestRunner(
+        tap_class=TapPostgres,
+        config=modified_config,
+        catalog=tap_catalog,
+    )
+    test_runner.sync_all()
+    
+    # Should only have the old record, recent record should be excluded by buffer
+    records = test_runner.records[altered_table_name]
+    assert len(records) == 1
+    assert records[0]["data"] == "OldRecord"
+
+
+def test_replication_key_buffer_seconds_disabled():
+    """Test that when buffer is not set, all records are processed."""
+    table_name = "test_replication_key_buffer_disabled"
+    
+    # Use config without buffer setting
+    modified_config = copy.deepcopy(SAMPLE_CONFIG)
+    
+    engine = sa.create_engine(modified_config["sqlalchemy_url"], future=True)
+
+    metadata_obj = sa.MetaData()
+    table = sa.Table(
+        table_name,
+        metadata_obj,
+        sa.Column("data", sa.String()),
+        sa.Column("updated_at", TIMESTAMP),
+    )
+    
+    current_time = datetime.datetime.now(datetime.timezone.utc)
+    
+    with engine.begin() as conn:
+        table.drop(conn, checkfirst=True)
+        metadata_obj.create_all(conn)
+        
+        # Insert old record
+        old_record_time = current_time - datetime.timedelta(seconds=60*10)  # 10 minutes ago
+        insert = table.insert().values(
+            data="OldRecord", 
+            updated_at=old_record_time
+        )
+        conn.execute(insert)
+        
+        # Insert recent record
+        recent_record_time = current_time - datetime.timedelta(seconds=60*4)  # 4 minutes ago
+        insert = table.insert().values(
+            data="RecentRecord", 
+            updated_at=recent_record_time
+        )
+        conn.execute(insert)
+    
+    tap = TapPostgres(config=modified_config)
+    tap_catalog = Catalog.from_dict(tap.catalog_dict)
+    altered_table_name = f"{DB_SCHEMA_NAME}-{table_name}"
+    
+    for stream in tap_catalog.streams:
+        if stream.stream and altered_table_name not in stream.stream:
+            for metadata in stream.metadata.values():
+                metadata.selected = False
+        else:
+            stream.replication_key = "updated_at"
+            for metadata in stream.metadata.values():
+                metadata.selected = True
+                if isinstance(metadata, StreamMetadata):
+                    metadata.forced_replication_method = "INCREMENTAL"
+                    metadata.replication_key = "updated_at"
+
+    test_runner = TapTestRunner(
+        tap_class=TapPostgres,
+        config=modified_config,
+        catalog=tap_catalog,
+    )
+    test_runner.sync_all()
+    
+    # Should have both records when buffer is not set
+    records = test_runner.records[altered_table_name]
+    assert len(records) == 2
+    record_data = {record["data"] for record in records}
+    assert record_data == {"OldRecord", "RecentRecord"}
+
+
+def test_replication_key_buffer_seconds_with_pacific_timezone():
+    """Test that replication_key_buffer_seconds works correctly with Pacific timezone data."""
+    table_name = "test_replication_key_buffer_pacific"
+    
+    # Create a config with a 300 second (5 minute) buffer
+    modified_config = copy.deepcopy(SAMPLE_CONFIG)
+    modified_config["replication_key_buffer_seconds"] = 300
+    
+    engine = sa.create_engine(modified_config["sqlalchemy_url"], future=True)
+
+    metadata_obj = sa.MetaData()
+    table = sa.Table(
+        table_name,
+        metadata_obj,
+        sa.Column("data", sa.String()),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True)),  # Use TIMESTAMPTZ to preserve timezone
+    )
+    
+    # Use Pacific timezone for test data
+    pacific_tz = zoneinfo.ZoneInfo("US/Pacific")
+    current_time_pacific = datetime.datetime.now(pacific_tz)
+    
+    with engine.begin() as conn:
+        table.drop(conn, checkfirst=True)
+        metadata_obj.create_all(conn)
+        
+        # Set PostgreSQL session timezone to Pacific to ensure data is stored in Pacific format
+        conn.execute(sa.text("SET timezone = 'US/Pacific'"))
+
+        # Insert record that's older than buffer (should be included)
+        old_record_time_pacific = current_time_pacific - datetime.timedelta(seconds=60*6)  # 6 minutes ago
+        insert = table.insert().values(
+            data="OldPacificRecord", 
+            updated_at=old_record_time_pacific
+        )
+        conn.execute(insert)
+        
+        # Insert record that's within buffer (should be excluded)
+        recent_record_time_pacific = current_time_pacific - datetime.timedelta(seconds=60*4)  # 4 minutes ago
+        insert = table.insert().values(
+            data="RecentPacificRecord", 
+            updated_at=recent_record_time_pacific
+        )
+        conn.execute(insert)
+        
+        # Verify the timestamps are stored with timezone information
+        result = conn.execute(sa.text(f"SELECT data, updated_at FROM {table_name} ORDER BY updated_at")).fetchall()
+        for row in result:
+            data, timestamp = row
+            # Verify the timestamp has timezone info when using TIMESTAMPTZ
+            assert hasattr(timestamp, 'tzinfo'), f"Timestamp for {data} should be timezone-aware"
+            assert timestamp.tzinfo is not None, f"Timestamp for {data} should have timezone info"
+        
+        # Verify the raw string representation contains Pacific timezone indicators
+        raw_result = conn.execute(sa.text(f"SELECT data, updated_at::text FROM {table_name} ORDER BY updated_at")).fetchall()
+        for row in raw_result:
+            data, timestamp_str = row
+            # Verify it contains Pacific timezone indicators
+            pacific_indicators = ['-08', '-07', 'PST', 'PDT']
+            assert any(tz_indicator in timestamp_str for tz_indicator in pacific_indicators), (
+                f"Timestamp string '{timestamp_str}' should contain Pacific timezone indicators"
+            )
+    
+    tap = TapPostgres(config=modified_config)
+    tap_catalog = Catalog.from_dict(tap.catalog_dict)
+    altered_table_name = f"{DB_SCHEMA_NAME}-{table_name}"
+    
+    for stream in tap_catalog.streams:
+        if stream.stream and altered_table_name not in stream.stream:
+            for metadata in stream.metadata.values():
+                metadata.selected = False
+        else:
+            stream.replication_key = "updated_at"
+            for metadata in stream.metadata.values():
+                metadata.selected = True
+                if isinstance(metadata, StreamMetadata):
+                    metadata.forced_replication_method = "INCREMENTAL"
+                    metadata.replication_key = "updated_at"
+
+    test_runner = TapTestRunner(
+        tap_class=TapPostgres,
+        config=modified_config,
+        catalog=tap_catalog,
+    )
+    test_runner.sync_all()
+    
+    # Should only have the old record, recent record should be excluded by buffer
+    records = test_runner.records[altered_table_name]
+    assert len(records) == 1
+    assert records[0]["data"] == "OldPacificRecord"
 
 class TapTestReplicationKey(TapTestTemplate):
     name = "replication_key"


### PR DESCRIPTION
add a buffer so that we don't process recent data. This avoids transaction race conditions and us missing updates.

https://sparelabs.slack.com/archives/C08ME4NGKSQ/p1749670962927459?thread_ts=1749667827.340759&cid=C08ME4NGKSQ