### PR TITLE
fix: Only require ca certificate when using verify-ca or verify-full

### DIFF
--- a/tap_postgres/tap.py
+++ b/tap_postgres/tap.py
@@ -396,9 +396,8 @@ class TapPostgres(SQLTap):
         if config["ssl_enable"]:
             ssl_mode = config["ssl_mode"]
             query.update({"sslmode": ssl_mode})
-            if (
-                ssl_mode in ("verify-ca", "verify-full")
-                and config.get("ssl_certificate_authority")
+            if ssl_mode in ("verify-ca", "verify-full") and config.get(
+                "ssl_certificate_authority"
             ):
                 query["sslrootcert"] = self.filepath_or_certificate(
                     value=config["ssl_certificate_authority"],


### PR DESCRIPTION
This change only looks for the ca certificate when using verify-ca or verify-full as modes like require do not need the ca cert.
This fixes #335 