### PR TITLE
fix: Initialize connector before accessing `connection_parameters` in `discover_streams`

### DIFF
--- a/tap_postgres/tap.py
+++ b/tap_postgres/tap.py
@@ -715,6 +715,10 @@ class TapPostgres(SQLTap):
         Returns:
             List of discovered Stream objects.
         """
+        # Access connector first to ensure connection_parameters is initialized.
+        # connection_parameters is set as a side effect of the connector property.
+        connector = self.connector
+
         streams: list[SQLStream] = []
         for catalog_entry in self.catalog_dict["streams"]:
             if catalog_entry["replication_method"] == "LOG_BASED":
@@ -723,9 +727,9 @@ class TapPostgres(SQLTap):
                         self,
                         catalog_entry,
                         connection_parameters=self.connection_parameters,
-                        connector=self.connector,
+                        connector=connector,
                     )
                 )
             else:
-                streams.append(PostgresStream(self, catalog_entry, connector=self.connector))
+                streams.append(PostgresStream(self, catalog_entry, connector=connector))
         return streams


### PR DESCRIPTION
The `connection_parameters` attribute is set as a side effect of the `connector` cached property. In `discover_streams`, accessing `self.connection_parameters` (for LOG_BASED streams) without first ensuring `self.connector` has been called could raise an AttributeError.

This change accesses the connector once at the top of the method, stores it in a local variable, and reuses it — guaranteeing initialization order and avoiding redundant cached property lookups in the loop.